### PR TITLE
🐛fix: 로그인되지 않은 사용자만 접근 가능하도록 인증 로직 수정

### DIFF
--- a/Dangnyang_Heroes/settings/base.py
+++ b/Dangnyang_Heroes/settings/base.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     "shelters",
     "recruitments",
     "rest_framework_simplejwt",
+    "rest_framework_simplejwt.token_blacklist",  # 블랙리스트 기능 추가
 ]
 
 MIDDLEWARE = [

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -369,3 +369,8 @@ class UserUpdateSerializer(serializers.ModelSerializer):
         if request and not request.user.is_authenticated:
             raise AuthenticationFailed({"message": "인증이 필요합니다."})
         return attrs
+
+
+# 🍒 로그아웃
+class LogoutSerializer(serializers.Serializer):
+    refresh_token = serializers.CharField()


### PR DESCRIPTION
## 🍎연관된 이슈

> ex) #28

## 🍌작업 내용

> 아이디찾기 외에도 로그인되지 않은 사용자만 접근 가능하도록 해야하는  API들 인증 로직 수정 완료,
로그아웃 시리얼라이저 추가함!

## 🥭스크린샷 (선택)

> 필요한 경우 첨부해주세요.

## 🍒리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
